### PR TITLE
Call of wrong attribute in line 185

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -182,7 +182,7 @@ class NetAppOntapDns(object):
 
     def apply(self):
         # asup logging
-        netapp_utils.ems_log_event("na_ontap_dns", self.vserver)
+        netapp_utils.ems_log_event("na_ontap_dns", self.server)
 
         dns_attrs = self.get_dns()
         changed = False


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixed by changing self.vserver to self.server

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
na_ontap_dns

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Create a dns entry on a SVM on a cdot system

Error:
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NetAppOntapDns' object has no attribute 'vserver'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_dCo2vu/ansible_module_na_ontap_dns.py\", line 211, in <module>\n    main()\n  File \"/tmp/ansible_dCo2vu/ansible_module_na_ontap_dns.py\", line 207, in main\n    obj.apply()\n  File \"/tmp/ansible_dCo2vu/ansible_module_na_ontap_dns.py\", line 185, in apply\n    netapp_utils.ems_log_event(\"na_ontap_dns\", self.vserver)\nAttributeError: 'NetAppOntapDns' object has no attribute 'vserver'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```
