### PR TITLE
fixed conditional "when" is missing pipe bool

### DIFF
--- a/na_ots_cluster/tasks/deploy_cluster.yml
+++ b/na_ots_cluster/tasks/deploy_cluster.yml
@@ -35,5 +35,4 @@
     job_id: "{{ cluster_deploy_response.json.job.id }}"
     job_retries: "{{ monitor_deploy_retries }}"
     job_delay: "{{ monitor_deploy_delay }}"
-  when:
-    - monitor_deploy_job
+  when: monitor_deploy_job|bool


### PR DESCRIPTION
The Ansible Role na_ots_cluster has a depreciated bare conditional in the task "deploy_cluster.yml". This actually only popped up as a warning saying it would be depreciated in 2.12 when creating a cluster and setting the var "monitor_deploy_job" to "True" to monitor the Select cluster installation to the end. 